### PR TITLE
Added printable options for the Orbit Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,17 @@ For complex products, like technology platforms, it's a best practice for the de
 - [Download the icons](https://github.com/orbit-love/orbit-model/raw/main/Orbit%20Emoji.zip)
 - [Read the blog post](https://orbit.love/blog/download-these-orbit-model-icons-for-your-slack-workspace)
 
+# Orbit Model printables
+
+Download and print the Orbit Model diagram (available in color and black/white)
+
+<p align="left">
+  <a href="https://github.com/orbit-love/orbit-model/raw/main/Printables.zip"><img alt="Orbit Model in color" src="images/orbit_model_color.png" width="360"></a>
+  <a href="https://github.com/orbit-love/orbit-model/raw/main/Printables.zip"><img alt="Orbit Model in black and white" src="images/orbit_model_bw.png" width="360"></a>
+</p>
+
+- [Download the images](https://github.com/orbit-love/orbit-model/raw/main/Printables.zip)
+
 # Early adopters
 
 Using the Orbit Model for your community? Tell the galaxy! Add your name to this list with a link to your site, community, or relevant material.


### PR DESCRIPTION
Orbit Model can now be downloaded and printed out (zip folder contains the 4 Orbit Model images - 2 b&w, 2 color - png & svg versions.

![Screenshot 2021-02-15 at 14 41 03](https://user-images.githubusercontent.com/45923677/107953946-1bfbcc00-6f9c-11eb-8a86-04b76114e4d1.png)
