### PR TITLE
[inconsistency] Restoring Gravity as main metric in KPI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Here's a summary of the most important things to measure when using the Orbit Mo
 
 | Metric         | Applies To                            | Calculation                              | Tells you...                                     |
 | -------------- | ------------------------------------- | ---------------------------------------- | ------------------------------------------------ |
-| Presence        | Whole community, orbit levels, groups | Sum(love \* reach) of each member        | Overall barometer for growth and engagement      |
+| Gravity        | Whole community, orbit levels, groups | Sum(love \* reach) of each member        | Overall barometer for growth and engagement      |
 | Level size     | Orbit levels 4, 3, 2, and 1           | Count of members at level                | How balanced the community is                    |
 | Orbit level    | Member                                | Chosen by Team, factoring in love        | What experience that member should get           |
 | Love           | Member                                | Maximum recent activity score (1-10)     | What contribution you can ask the member to make |


### PR DESCRIPTION
Hello Orbit team 👋 

I’m prepping interviews with your team (very happy about the opportunity!), and on re-reading the model I got blocked on this one line in the KPI section. As far as I can tell the calculation formula really corresponds to _Gravity_ calculation (as explained in [Measuring gravity](https://github.com/orbit-love/orbit-model/blob/main/README.md#measuring-gravity)) and doesn’t describe _Presence_. Plus I feel it’s consistent with _Gravity_ being the main community-level KPI too.

From a quick git history digging, it seems [this commit](https://github.com/orbit-love/orbit-model/commit/1359e38a7c748160815074a740cb46300c3981ff) restored _Gravity_ instead of _Presence_ in a number of sections, so maybe this line here in this table was just missed!

And if the current version is actually ok then I’m obviously happy to know more about what I’m missing 💡 

Thanks for reading 🙌
Nico